### PR TITLE
feat: pickpocket except against multidrop monsters

### DIFF
--- a/src/macro.ts
+++ b/src/macro.ts
@@ -171,7 +171,8 @@ export default class Macro extends StrictMacro {
   }
 
   standardCombat(): this {
-    return this.tryHaveSkill($skill`Curse of Weaksauce`)
+    return this.if_("!monstername Crimbuccaneer mudlark && !monstername Elf Guard engineer", "pickpocket")
+      .tryHaveSkill($skill`Curse of Weaksauce`)
       .familiarActions()
       .externalIf(
         SongBoom.song() === "Total Eclipse of Your Meat",

--- a/src/outfit.ts
+++ b/src/outfit.ts
@@ -223,41 +223,43 @@ const accessories: { item: Item; valueFunction: (options: AccessoryOptions) => n
       }
       // about 5% of a common drop
       const aff = chosenAffiliation();
-      if (location == $location`Abuela's Cottage (Contested)`) {
-        if (aff == "pirates") {
+      /* eslint-disable libram/verify-constants */
+      if (location === $location`Abuela's Cottage (Contested)`) {
+        if (aff === "pirates") {
           return 0.05 * garboAverageValue($item`Elf Guard officer's sidearm`, $item`Elf Guard commandeering gloves`, $item`Elf Guard eyedrops`);
         }
-        if (aff == "elves") {
+        if (aff === "elves") {
           return 0.05 * garboAverageValue($item`Crimbuccaneer shirt`, $item`Crimbuccaneer captain's purse`);
         }
-      } else if (location == $location`The Embattled Factory`) {
-        if (aff == "pirates") {
+      } else if (location === $location`The Embattled Factory`) {
+        if (aff === "pirates") {
           return 0.05 * garboAverageValue($item`military-grade peppermint oil`, $item`Elf Guard tinsel grenade`);
         }
-        if (aff == "elves") {
+        if (aff === "elves") {
           return 0.05 * garboAverageValue($item`Crimbuccaneer mologrog cocktail`, $item`Crimbuccaneer whale oil`, $item`Crimbuccaneer rigging lasso`);
         }
-      } else if (location == $location`The Bar At War`) {
-        if (aff == "pirates") {
+      } else if (location === $location`The Bar At War`) {
+        if (aff === "pirates") {
           return 0.05 * garboAverageValue($item`bottle of whiskey`, $item`peppermint bomb`, $item`officer's nog`);
         }
-        if (aff == "elves") {
+        if (aff === "elves") {
           return 0.05 * garboAverageValue($item`grog nuts`, $item`sawed-off blunderbuss`, $item`old-school pirate grog`);
         }
-      } else if (location == $location`A Cafe Divided`) {
-        if (aff == "pirates") {
+      } else if (location === $location`A Cafe Divided`) {
+        if (aff === "pirates") {
           return 0.05 * garboAverageValue($item`sundae ration`, $item`peppermint tack`, $item`Elf Guard payroll bag`);
         }
-        if (aff == "elves") {
+        if (aff === "elves") {
           return 0.05 * garboAverageValue($item`orange`, $item`pegfinger`, $item`whalesteak`);
         }
-      } else if (location == $location`The Armory Up In Arms`) {
-        if (aff == "pirates") {
+      } else if (location === $location`The Armory Up In Arms`) {
+        if (aff === "pirates") {
           return 0.05 * garboAverageValue($item`Elf Guard mouthknife`, $item`Kelflar vest`, $item`red and white claret`);
         }
-        if (aff == "elves") {
+        if (aff === "elves") {
           return 0.05 * garboAverageValue($item`shipwright's hammer`, $item`cannonbomb`, $item`whale cerebrospinal fluid`);
         }
+        /* eslint-enable libram/verify-constants */
       }
       return 0;
     },

--- a/src/outfit.ts
+++ b/src/outfit.ts
@@ -6,10 +6,12 @@ import {
   Item,
   itemAmount,
   Location,
+  myClass,
   toSlot,
   totalTurnsPlayed,
 } from "kolmafia";
 import {
+  $classes,
   $familiar,
   $familiars,
   $item,
@@ -210,6 +212,12 @@ const accessories: { item: Item; valueFunction: (options: AccessoryOptions) => n
     item: $item`Elf Guard commandeering gloves`,
     valueFunction: ({ location }) =>
       location.zone === "Crimbo23" && chosenAffiliation() === "elves" ? 10000 : 0,
+  },
+  {
+    item: $item`mime army infiltration glove`,
+    // if we can already pickpocket, it's worthless; otherwise it's worth ~5% of a common drop
+    // which is about 2k for the farmables at the moment
+    valueFunction: () => $classes`Disco Bandit, Accordion Thief`.includes(myClass()) ? 0 : 2000,
   },
 ];
 

--- a/src/outfit.ts
+++ b/src/outfit.ts
@@ -15,6 +15,7 @@ import {
   $familiar,
   $familiars,
   $item,
+  $location,
   CrystalBall,
   get,
   getRemainingStomach,
@@ -23,7 +24,7 @@ import {
 } from "libram";
 
 import { freeFightFamiliar, MenuOptions } from "./familiar";
-import { garboValue } from "./garboValue";
+import { garboAverageValue, garboValue } from "./garboValue";
 import { args, chosenAffiliation, getOrbTarget, realmAvailable, sober } from "./lib";
 import * as OrbManager from "./orbmanager";
 
@@ -215,9 +216,51 @@ const accessories: { item: Item; valueFunction: (options: AccessoryOptions) => n
   },
   {
     item: $item`mime army infiltration glove`,
-    // if we can already pickpocket, it's worthless; otherwise it's worth ~5% of a common drop
-    // which is about 2k for the farmables at the moment
-    valueFunction: () => $classes`Disco Bandit, Accordion Thief`.includes(myClass()) ? 0 : 2000,
+    valueFunction: ({ location }) => {
+      // if we can already pickpocket or can't even with this, it's worthless
+      if ($classes`Disco Bandit, Accordion Thief`.includes(myClass()) || !sober()) {
+        return 0;
+      }
+      // about 5% of a common drop
+      const aff = chosenAffiliation();
+      if (location == $location`Abuela's Cottage (Contested)`) {
+        if (aff == "pirates") {
+          return 0.05 * garboAverageValue($item`Elf Guard officer's sidearm`, $item`Elf Guard commandeering gloves`, $item`Elf Guard eyedrops`);
+        }
+        if (aff == "elves") {
+          return 0.05 * garboAverageValue($item`Crimbuccaneer shirt`, $item`Crimbuccaneer captain's purse`);
+        }
+      } else if (location == $location`The Embattled Factory`) {
+        if (aff == "pirates") {
+          return 0.05 * garboAverageValue($item`military-grade peppermint oil`, $item`Elf Guard tinsel grenade`);
+        }
+        if (aff == "elves") {
+          return 0.05 * garboAverageValue($item`Crimbuccaneer mologrog cocktail`, $item`Crimbuccaneer whale oil`, $item`Crimbuccaneer rigging lasso`);
+        }
+      } else if (location == $location`The Bar At War`) {
+        if (aff == "pirates") {
+          return 0.05 * garboAverageValue($item`bottle of whiskey`, $item`peppermint bomb`, $item`officer's nog`);
+        }
+        if (aff == "elves") {
+          return 0.05 * garboAverageValue($item`grog nuts`, $item`sawed-off blunderbuss`, $item`old-school pirate grog`);
+        }
+      } else if (location == $location`A Cafe Divided`) {
+        if (aff == "pirates") {
+          return 0.05 * garboAverageValue($item`sundae ration`, $item`peppermint tack`, $item`Elf Guard payroll bag`);
+        }
+        if (aff == "elves") {
+          return 0.05 * garboAverageValue($item`orange`, $item`pegfinger`, $item`whalesteak`);
+        }
+      } else if (location == $location`The Armory Up In Arms`) {
+        if (aff == "pirates") {
+          return 0.05 * garboAverageValue($item`Elf Guard mouthknife`, $item`Kelflar vest`, $item`red and white claret`);
+        }
+        if (aff == "elves") {
+          return 0.05 * garboAverageValue($item`shipwright's hammer`, $item`cannonbomb`, $item`whale cerebrospinal fluid`);
+        }
+      }
+      return 0;
+    },
   },
 ];
 


### PR DESCRIPTION
You can pickpocket the common drops, so try to do that. However, don't try against the mudlark or engineer: these drop 1-3 of the flotsam or machine parts normally, and if you pickpocket you always get one.

Don't condition on being able to pickpocket because if you submit a macro where you try to pickpocket but can't, you just don't. Efficient! And also I'm not certain how to check for this without enumerating all the possible cases.

Value mime army infiltration glove at 2k: it's about 5% of a common drop, and the farmable ones are 30k-50k. Might get a better valuation later but I think this is good enough for now.