### PR TITLE
Adds basic T.U.R.D.S key support and waffle support and other fixes 

### DIFF
--- a/src/islands.ts
+++ b/src/islands.ts
@@ -1,9 +1,10 @@
 import { Element, Item, Location, Monster } from "kolmafia";
-import { $element, $item, $location, $monster } from "libram";
+import { $element, $item, $location, $monster, $monsters } from "libram";
 
 export type HolidayIsland = {
   location: Location;
   orbTarget: Monster;
+  avoidMonsters: Monster[];
   element: Element;
   choice: number;
   currency: Item;
@@ -13,6 +14,7 @@ const Easter: HolidayIsland = {
   location: $location`Easter Island`,
   element: $element`Stench`,
   orbTarget: $monster`moai`,
+  avoidMonsters: $monsters`chocolate chicken, feral bunny`,
   choice: 1538,
   currency: $item`Spirit of Easter`,
 };
@@ -21,6 +23,7 @@ const StPatricksDay: HolidayIsland = {
   location: $location`St. Patrick's Day Island`,
   element: $element`Sleaze`,
   orbTarget: $monster`giant potato`,
+  avoidMonsters: $monsters`giant snake, giant potato snake`,
   choice: 1539,
   currency: $item`Spirit of St. Patrick's Day`,
 };
@@ -29,6 +32,7 @@ const VeteransDay: HolidayIsland = {
   location: $location`Veterans Day Island`,
   element: $element`Hot`,
   orbTarget: $monster`Section 11`,
+  avoidMonsters: $monsters`Brandonian loyalist, spectre of war`,
   choice: 1540,
   currency: $item`Spirit of Veteran's Day`,
 };
@@ -37,6 +41,7 @@ const Thanksgiving: HolidayIsland = {
   location: $location`Thanksgiving Island`,
   element: $element`Cold`,
   orbTarget: $monster`pumpkin spice wraith`,
+  avoidMonsters: $monsters`gravy slime, possessed can of cream of mushroom soup, possessed can of green beans`,
   choice: 1541,
   currency: $item`Spirit of Thanksgiving`,
 };
@@ -48,6 +53,7 @@ const Christmas: HolidayIsland = {
   // eslint-disable-next-line libram/verify-constants
   orbTarget: $monster`magically-animated snowman`,
   // eslint-disable-next-line libram/verify-constants
+  avoidMonsters: $monsters`Christmas treant, self-driving sleigh`,
   choice: 1542,
   currency: $item`Spirit of Christmas`,
 };

--- a/src/islands.ts
+++ b/src/islands.ts
@@ -4,7 +4,7 @@ import { $element, $item, $location, $monster, $monsters } from "libram";
 export type HolidayIsland = {
   location: Location;
   orbTarget: Monster;
-  waffleAway: Monster[];
+  avoidMonsters: Monster[];
   element: Element;
   choice: number;
   currency: Item;
@@ -14,7 +14,7 @@ const Easter: HolidayIsland = {
   location: $location`Easter Island`,
   element: $element`Stench`,
   orbTarget: $monster`moai`,
-  waffleAway: $monsters`chocolate chicken, feral bunny`,
+  avoidMonsters: $monsters`chocolate chicken, feral bunny`,
   choice: 1538,
   currency: $item`Spirit of Easter`,
 };
@@ -23,7 +23,7 @@ const StPatricksDay: HolidayIsland = {
   location: $location`St. Patrick's Day Island`,
   element: $element`Sleaze`,
   orbTarget: $monster`giant potato`,
-  waffleAway: $monsters`giant snake, giant potato snake`,
+  avoidMonsters: $monsters`giant snake, giant potato snake`,
   choice: 1539,
   currency: $item`Spirit of St. Patrick's Day`,
 };
@@ -32,7 +32,7 @@ const VeteransDay: HolidayIsland = {
   location: $location`Veterans Day Island`,
   element: $element`Hot`,
   orbTarget: $monster`Section 11`,
-  waffleAway: $monsters`Brandonian loyalist, spectre of war`,
+  avoidMonsters: $monsters`Brandonian loyalist, spectre of war`,
   choice: 1540,
   currency: $item`Spirit of Veteran's Day`,
 };
@@ -41,7 +41,7 @@ const Thanksgiving: HolidayIsland = {
   location: $location`Thanksgiving Island`,
   element: $element`Cold`,
   orbTarget: $monster`pumpkin spice wraith`,
-  waffleAway: $monsters`gravy slime, possessed can of cream of mushroom soup, possessed can of green beans`,
+  avoidMonsters: $monsters`gravy slime, possessed can of cream of mushroom soup, possessed can of green beans`,
   choice: 1541,
   currency: $item`Spirit of Thanksgiving`,
 };
@@ -53,7 +53,7 @@ const Christmas: HolidayIsland = {
   // eslint-disable-next-line libram/verify-constants
   orbTarget: $monster`magically-animated snowman`,
   // eslint-disable-next-line libram/verify-constants
-  waffleAway: $monsters`Christmas treant, self-driving sleigh`,
+  avoidMonsters: $monsters`Christmas treant, self-driving sleigh`,
   choice: 1542,
   currency: $item`Spirit of Christmas`,
 };

--- a/src/islands.ts
+++ b/src/islands.ts
@@ -1,10 +1,9 @@
 import { Element, Item, Location, Monster } from "kolmafia";
-import { $element, $item, $location, $monster, $monsters } from "libram";
+import { $element, $item, $location, $monster } from "libram";
 
 export type HolidayIsland = {
   location: Location;
   orbTarget: Monster;
-  avoidMonsters: Monster[];
   element: Element;
   choice: number;
   currency: Item;
@@ -14,7 +13,6 @@ const Easter: HolidayIsland = {
   location: $location`Easter Island`,
   element: $element`Stench`,
   orbTarget: $monster`moai`,
-  avoidMonsters: $monsters`chocolate chicken, feral bunny`,
   choice: 1538,
   currency: $item`Spirit of Easter`,
 };
@@ -23,7 +21,6 @@ const StPatricksDay: HolidayIsland = {
   location: $location`St. Patrick's Day Island`,
   element: $element`Sleaze`,
   orbTarget: $monster`giant potato`,
-  avoidMonsters: $monsters`giant snake, giant potato snake`,
   choice: 1539,
   currency: $item`Spirit of St. Patrick's Day`,
 };
@@ -32,7 +29,6 @@ const VeteransDay: HolidayIsland = {
   location: $location`Veterans Day Island`,
   element: $element`Hot`,
   orbTarget: $monster`Section 11`,
-  avoidMonsters: $monsters`Brandonian loyalist, spectre of war`,
   choice: 1540,
   currency: $item`Spirit of Veteran's Day`,
 };
@@ -41,7 +37,6 @@ const Thanksgiving: HolidayIsland = {
   location: $location`Thanksgiving Island`,
   element: $element`Cold`,
   orbTarget: $monster`pumpkin spice wraith`,
-  avoidMonsters: $monsters`gravy slime, possessed can of cream of mushroom soup, possessed can of green beans`,
   choice: 1541,
   currency: $item`Spirit of Thanksgiving`,
 };
@@ -53,7 +48,6 @@ const Christmas: HolidayIsland = {
   // eslint-disable-next-line libram/verify-constants
   orbTarget: $monster`magically-animated snowman`,
   // eslint-disable-next-line libram/verify-constants
-  avoidMonsters: $monsters`Christmas treant, self-driving sleigh`,
   choice: 1542,
   currency: $item`Spirit of Christmas`,
 };

--- a/src/islands.ts
+++ b/src/islands.ts
@@ -1,9 +1,10 @@
 import { Element, Item, Location, Monster } from "kolmafia";
-import { $element, $item, $location, $monster } from "libram";
+import { $element, $item, $location, $monster, $monsters } from "libram";
 
 export type HolidayIsland = {
   location: Location;
   orbTarget: Monster;
+  waffleAway: Monster[];
   element: Element;
   choice: number;
   currency: Item;
@@ -13,6 +14,7 @@ const Easter: HolidayIsland = {
   location: $location`Easter Island`,
   element: $element`Stench`,
   orbTarget: $monster`moai`,
+  waffleAway: $monsters`chocolate chicken, feral bunny`,
   choice: 1538,
   currency: $item`Spirit of Easter`,
 };
@@ -21,6 +23,7 @@ const StPatricksDay: HolidayIsland = {
   location: $location`St. Patrick's Day Island`,
   element: $element`Sleaze`,
   orbTarget: $monster`giant potato`,
+  waffleAway: $monsters`giant snake, giant potato snake`,
   choice: 1539,
   currency: $item`Spirit of St. Patrick's Day`,
 };
@@ -29,6 +32,7 @@ const VeteransDay: HolidayIsland = {
   location: $location`Veterans Day Island`,
   element: $element`Hot`,
   orbTarget: $monster`Section 11`,
+  waffleAway: $monsters`Brandonian loyalist, spectre of war`,
   choice: 1540,
   currency: $item`Spirit of Veteran's Day`,
 };
@@ -37,6 +41,7 @@ const Thanksgiving: HolidayIsland = {
   location: $location`Thanksgiving Island`,
   element: $element`Cold`,
   orbTarget: $monster`pumpkin spice wraith`,
+  waffleAway: $monsters`gravy slime, possessed can of cream of mushroom soup, possessed can of green beans`,
   choice: 1541,
   currency: $item`Spirit of Thanksgiving`,
 };
@@ -47,6 +52,8 @@ const Christmas: HolidayIsland = {
   element: $element`spooky`,
   // eslint-disable-next-line libram/verify-constants
   orbTarget: $monster`magically-animated snowman`,
+  // eslint-disable-next-line libram/verify-constants
+  waffleAway: $monsters`Christmas treant, self-driving sleigh`,
   choice: 1542,
   currency: $item`Spirit of Christmas`,
 };

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -89,6 +89,14 @@ export const args = Args.create("crimbo24", "A script for farming elf stuff", {
     help: "Whether to use the Crimbo Shrub when farming Crimbo zones.",
     default: false,
   }),
+  turdsKey: Args.boolean({
+    help: "Should this script try to use T.U.R.D.S key when encountering `spectre of war`",
+    default: false,
+  }),
+  waffles: Args.boolean({
+    help: "Should this script try to waffle away every single monster as long as it has waffles, except the rare dropping ones? Caution, this will rapidly drain your inventory of waffles!",
+    default: false,
+  }),
   debug: Args.flag({
     help: "Turn on debug printing",
     default: false,

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -98,7 +98,7 @@ export const args = Args.create("crimbo24", "A script for farming elf stuff", {
     default: false,
   }),
   freeruns: Args.boolean({
-    help: "Should the script try to freerun with GAP / Navel Gazing Ring if the monster isn't one of the rare droppers? This means you will receive less Spirits",
+    help: "Should the script try to freerun with GAP / Navel Gazing Ring if the monster isn't one of the rare droppers? This means you will forfeit the drops of other monsters.",
     default: false,
   }),
   debug: Args.flag({

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -90,7 +90,7 @@ export const args = Args.create("crimbo24", "A script for farming elf stuff", {
     default: false,
   }),
   turdsKey: Args.boolean({
-    help: "Should this script try to use T.U.R.D.S key when encountering `spectre of war`",
+    help: "Should this script try to use T.U.R.D.S key when encountering `spectre of war` for 20 turns of Everything Looks <Cooldown Color> instead of the normal 30",
     default: false,
   }),
   waffles: Args.boolean({

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -97,6 +97,10 @@ export const args = Args.create("crimbo24", "A script for farming elf stuff", {
     help: "Should this script try to waffle away every single monster as long as it has waffles, except the rare dropping ones? Caution, this will rapidly drain your inventory of waffles!",
     default: false,
   }),
+  freeruns: Args.boolean({
+    help: "Should the script try to freerun with GAP / Navel Gazing Ring if the monster isn't one of the rare droppers? This means you will receive less Spirits",
+    default: false,
+  }),
   debug: Args.flag({
     help: "Turn on debug printing",
     default: false,

--- a/src/macro.ts
+++ b/src/macro.ts
@@ -231,13 +231,17 @@ export default class Macro extends StrictMacro {
     else return this;
   }
 
+  waffleOrRun(island: HolidayIsland): this {
+    return this.waffle(island).gapRunIfUnwantedMonster(island);
+  }
+
   waffle(island: HolidayIsland): this {
     if (args.waffles)
       return this.while_(
-        `hascombatitem waffle && ${island.waffleAway
-          .map((m) => `monsterid "${m.id}"`)
+        `hascombatitem waffle && ${island.avoidMonsters
+          .map((m) => `monsterid ${m.id}`)
           .join(" || ")}`,
-        Macro.tKey().item(Item.get("waffle"))
+        Macro.tKey().tearawayPants().item(Item.get("waffle"))
       );
     else return this;
   }
@@ -246,12 +250,29 @@ export default class Macro extends StrictMacro {
     return this.pickpocket()
       .tKey()
       .trySkill($skill`Launch spikolodon spikes`)
-      .externalIf(
-        haveEquipped($item`tearaway pants`),
-        Macro.if_("!pastround 1 && monsterphylum plant", Macro.skill($skill`Tear Away your Pants!`))
-      )
+      .tearawayPants()
       .waffle(island)
       .itemOrSkill(thing);
+  }
+
+  gapRunIfUnwantedMonster(island: HolidayIsland): this {
+    // If wearing GAP / Navel ring, then run if its an undesired monster
+    return this.externalIf(
+      $items`Greatest American Pants, navel ring of navel gazing`.some((item) =>
+        haveEquipped(item)
+      ),
+      Macro.if_(
+        `${island.avoidMonsters.map((m) => `monsterid ${m.id}`).join(" || ")}`,
+        Macro.runaway()
+      )
+    );
+  }
+
+  tearawayPants(): this {
+    return this.externalIf(
+      haveEquipped($item`tearaway pants`),
+      Macro.if_("!pastround 1 && monsterphylum plant", Macro.skill($skill`Tear Away your Pants!`))
+    );
   }
 
   static islandKillWith(island: HolidayIsland, thing: Item | Skill): Macro {
@@ -266,10 +287,7 @@ export default class Macro extends StrictMacro {
     return this.pickpocket()
       .tKey()
       .trySkill($skill`Launch spikolodon spikes`)
-      .externalIf(
-        haveEquipped($item`tearaway pants`),
-        Macro.if_("!pastround 1 && monsterphylum plant", Macro.skill($skill`Tear Away your Pants!`))
-      )
+      .tearawayPants()
       .itemOrSkill(thing);
   }
 
@@ -281,11 +299,8 @@ export default class Macro extends StrictMacro {
     return Macro.pickpocket()
       .tKey()
       .trySkill($skill`Launch spikolodon spikes`)
-      .externalIf(
-        haveEquipped($item`tearaway pants`),
-        Macro.if_("!pastround 1 && monsterphylum plant", Macro.skill($skill`Tear Away your Pants!`))
-      )
-      .waffle(island)
+      .tearawayPants()
+      .waffleOrRun(island)
       .attack()
       .repeat("!pastround 3")
       .hardCombat();

--- a/src/macro.ts
+++ b/src/macro.ts
@@ -258,9 +258,10 @@ export default class Macro extends StrictMacro {
   gapRunIfUnwantedMonster(island: HolidayIsland): this {
     // If wearing GAP / Navel ring, then run if its an undesired monster
     return this.externalIf(
-      $items`Greatest American Pants, navel ring of navel gazing`.some((item) =>
-        haveEquipped(item)
-      ),
+      args.freeruns &&
+        $items`Greatest American Pants, navel ring of navel gazing`.some((item) =>
+          haveEquipped(item)
+        ),
       Macro.if_(
         `${island.avoidMonsters.map((m) => `monsterid ${m.id}`).join(" || ")}`,
         Macro.runaway()

--- a/src/macro.ts
+++ b/src/macro.ts
@@ -222,6 +222,10 @@ export default class Macro extends StrictMacro {
 
   islandKillWith(thing: Item | Skill): this {
     return this.pickpocket()
+      .if_(
+        `!haseffect 2881 && monstername spectre of war`,
+        Macro.tryHaveItem(Item.get("T.U.R.D.S. Key"))
+      )
       .trySkill($skill`Launch spikolodon spikes`)
       .externalIf(
         haveEquipped($item`tearaway pants`),
@@ -236,6 +240,10 @@ export default class Macro extends StrictMacro {
 
   islandRunWith(thing: Item | Skill): this {
     return this.pickpocket()
+      .if_(
+        `!haseffect 2881 && monstername spectre of war`,
+        Macro.tryHaveItem(Item.get("T.U.R.D.S. Key"))
+      )
       .trySkill($skill`Launch spikolodon spikes`)
       .externalIf(
         haveEquipped($item`tearaway pants`),
@@ -250,6 +258,10 @@ export default class Macro extends StrictMacro {
 
   static islandCombat(): Macro {
     return Macro.pickpocket()
+      .if_(
+        `!haseffect 2881 && monstername spectre of war`,
+        Macro.tryHaveItem(Item.get("T.U.R.D.S. Key"))
+      )
       .trySkill($skill`Launch spikolodon spikes`)
       .externalIf(
         haveEquipped($item`tearaway pants`),

--- a/src/macro.ts
+++ b/src/macro.ts
@@ -305,6 +305,7 @@ export default class Macro extends StrictMacro {
       .trySkill($skill`Launch spikolodon spikes`)
       .tearawayPants()
       .waffleOrRun(island)
+      .if_($monster`pumpkin spice wraith`, new Macro().tryHaveItem($item`traumatic holiday memory`))
       .attack()
       .repeat("!pastround 3")
       .hardCombat();

--- a/src/macro.ts
+++ b/src/macro.ts
@@ -238,9 +238,9 @@ export default class Macro extends StrictMacro {
   waffle(island: HolidayIsland): this {
     if (args.waffles)
       return this.while_(
-        `hascombatitem waffle && ${island.avoidMonsters
+        `hascombatitem waffle && (${island.avoidMonsters
           .map((m) => `monsterid ${m.id}`)
-          .join(" || ")}`,
+          .join(" || ")})`,
         Macro.tKey().tearawayPants().item(Item.get("waffle"))
       );
     else return this;

--- a/src/macro.ts
+++ b/src/macro.ts
@@ -283,16 +283,19 @@ export default class Macro extends StrictMacro {
     return new Macro().tKey();
   }
 
-  islandRunWith(thing: Item | Skill): this {
+  islandRunWith(island: HolidayIsland, thing: Item | Skill): this {
     return this.pickpocket()
       .tKey()
       .trySkill($skill`Launch spikolodon spikes`)
       .tearawayPants()
-      .itemOrSkill(thing);
+      .ifNot(island.orbTarget, new Macro().itemOrSkill(thing))
+      .attack()
+      .repeat("!pastround 3")
+      .hardCombat();
   }
 
-  static islandRunWith(thing: Item | Skill): Macro {
-    return new Macro().islandRunWith(thing);
+  static islandRunWith(island: HolidayIsland, thing: Item | Skill): Macro {
+    return new Macro().islandRunWith(island, thing);
   }
 
   static islandCombat(island: HolidayIsland): Macro {

--- a/src/macro.ts
+++ b/src/macro.ts
@@ -289,7 +289,10 @@ export default class Macro extends StrictMacro {
       .tKey()
       .trySkill($skill`Launch spikolodon spikes`)
       .tearawayPants()
-      .ifNot(island.orbTarget, new Macro().itemOrSkill(thing))
+      .if_(
+        `${island.avoidMonsters.map((m) => `monsterid ${m.id}`).join(" || ")}`,
+        new Macro().itemOrSkill(thing)
+      )
       .attack()
       .repeat("!pastround 3")
       .hardCombat();

--- a/src/macro.ts
+++ b/src/macro.ts
@@ -13,6 +13,7 @@ import {
 } from "kolmafia";
 import {
   $class,
+  $effect,
   $familiar,
   $item,
   $items,
@@ -223,9 +224,9 @@ export default class Macro extends StrictMacro {
 
   tKey(): this {
     if (args.turdsKey)
-      return this.if_(
-        `!haseffect 2881 && monstername spectre of war && hascombatitem "T.U.R.D.S. Key"`,
-        Macro.item(Item.get("T.U.R.D.S. Key"))
+      return this.ifNot(
+        $effect`Everything Looks Green`,
+        Macro.if_($monster`spectre of war`, Macro.tryHaveItem(Item.get("T.U.R.D.S. Key")))
       );
     else return this;
   }
@@ -234,7 +235,7 @@ export default class Macro extends StrictMacro {
     if (args.waffles)
       return this.while_(
         `hascombatitem waffle && ${island.waffleAway
-          .map((m) => `monstername "${m.name}"`)
+          .map((m) => `monsterid "${m.id}"`)
           .join(" || ")}`,
         Macro.tKey().item(Item.get("waffle"))
       );

--- a/src/macro.ts
+++ b/src/macro.ts
@@ -222,13 +222,16 @@ export default class Macro extends StrictMacro {
     else return this.skill(thing);
   }
 
+  static itemOrSkill(thing: Item | Skill): Macro {
+    return new Macro().itemOrSkill(thing);
+  }
+
   tKey(): this {
-    if (args.turdsKey)
-      return this.ifNot(
-        $effect`Everything Looks Green`,
-        Macro.if_($monster`spectre of war`, Macro.tryHaveItem(Item.get("T.U.R.D.S. Key")))
-      );
-    else return this;
+    if (args.turdsKey && !have($effect`Everything Looks Green`)) {
+      return this.if_($monster`spectre of war`, Macro.tryHaveItem($item`T.U.R.D.S. Key`));
+    }
+
+    return this;
   }
 
   waffleOrRun(island: HolidayIsland): this {
@@ -238,10 +241,10 @@ export default class Macro extends StrictMacro {
   waffle(island: HolidayIsland): this {
     if (args.waffles)
       return this.while_(
-        `hascombatitem waffle && (${island.avoidMonsters
-          .map((m) => `monsterid ${m.id}`)
-          .join(" || ")})`,
-        Macro.tKey().tearawayPants().item(Item.get("waffle"))
+        `hascombatitem waffle && !monsterid ${island.orbTarget.id}`,
+        Macro.tKey()
+          .tearawayPants()
+          .item($item`waffle`)
       );
     else return this;
   }
@@ -262,10 +265,7 @@ export default class Macro extends StrictMacro {
         $items`Greatest American Pants, navel ring of navel gazing`.some((item) =>
           haveEquipped(item)
         ),
-      Macro.if_(
-        `${island.avoidMonsters.map((m) => `monsterid ${m.id}`).join(" || ")}`,
-        Macro.runaway()
-      )
+      Macro.ifNot(island.orbTarget, Macro.runaway())
     );
   }
 
@@ -286,13 +286,10 @@ export default class Macro extends StrictMacro {
 
   islandRunWith(island: HolidayIsland, thing: Item | Skill): this {
     return this.pickpocket()
-      .tKey()
-      .trySkill($skill`Launch spikolodon spikes`)
       .tearawayPants()
-      .if_(
-        `${island.avoidMonsters.map((m) => `monsterid ${m.id}`).join(" || ")}`,
-        new Macro().itemOrSkill(thing)
-      )
+      .trySkill($skill`Launch spikolodon spikes`)
+      .tKey()
+      .ifNot(island.orbTarget, Macro.itemOrSkill(thing))
       .attack()
       .repeat("!pastround 3")
       .hardCombat();
@@ -304,9 +301,9 @@ export default class Macro extends StrictMacro {
 
   static islandCombat(island: HolidayIsland): Macro {
     return Macro.pickpocket()
-      .tKey()
       .trySkill($skill`Launch spikolodon spikes`)
       .tearawayPants()
+      .tKey()
       .waffleOrRun(island)
       .if_($monster`pumpkin spice wraith`, new Macro().tryHaveItem($item`traumatic holiday memory`))
       .attack()

--- a/src/macro.ts
+++ b/src/macro.ts
@@ -28,7 +28,8 @@ import {
 } from "libram";
 
 import { canOpenRedPresent, timeToMeatify } from "./familiar";
-import { shouldRedigitize } from "./lib";
+import { HolidayIsland } from "./islands";
+import { args, shouldRedigitize } from "./lib";
 
 const gooKillSkills = [
   { skill: $skill`Nantlers`, stat: $stat`muscle` },
@@ -220,30 +221,49 @@ export default class Macro extends StrictMacro {
     else return this.skill(thing);
   }
 
-  islandKillWith(thing: Item | Skill): this {
+  tKey(): this {
+    if (args.turdsKey)
+      return this.if_(
+        `!haseffect 2881 && monstername spectre of war && hascombatitem "T.U.R.D.S. Key"`,
+        Macro.item(Item.get("T.U.R.D.S. Key"))
+      );
+    else return this;
+  }
+
+  waffle(island: HolidayIsland): this {
+    if (args.waffles)
+      return this.while_(
+        `hascombatitem waffle && ${island.waffleAway
+          .map((m) => `monstername "${m.name}"`)
+          .join(" || ")}`,
+        Macro.tKey().item(Item.get("waffle"))
+      );
+    else return this;
+  }
+
+  islandKillWith(island: HolidayIsland, thing: Item | Skill): this {
     return this.pickpocket()
-      .if_(
-        `!haseffect 2881 && monstername spectre of war`,
-        Macro.tryHaveItem(Item.get("T.U.R.D.S. Key"))
-      )
+      .tKey()
       .trySkill($skill`Launch spikolodon spikes`)
       .externalIf(
         haveEquipped($item`tearaway pants`),
         Macro.if_("!pastround 1 && monsterphylum plant", Macro.skill($skill`Tear Away your Pants!`))
       )
+      .waffle(island)
       .itemOrSkill(thing);
   }
 
-  static islandKillWith(thing: Item | Skill): Macro {
-    return new Macro().islandKillWith(thing);
+  static islandKillWith(island: HolidayIsland, thing: Item | Skill): Macro {
+    return new Macro().islandKillWith(island, thing);
+  }
+
+  static tKey(): Macro {
+    return new Macro().tKey();
   }
 
   islandRunWith(thing: Item | Skill): this {
     return this.pickpocket()
-      .if_(
-        `!haseffect 2881 && monstername spectre of war`,
-        Macro.tryHaveItem(Item.get("T.U.R.D.S. Key"))
-      )
+      .tKey()
       .trySkill($skill`Launch spikolodon spikes`)
       .externalIf(
         haveEquipped($item`tearaway pants`),
@@ -256,17 +276,15 @@ export default class Macro extends StrictMacro {
     return new Macro().islandRunWith(thing);
   }
 
-  static islandCombat(): Macro {
+  static islandCombat(island: HolidayIsland): Macro {
     return Macro.pickpocket()
-      .if_(
-        `!haseffect 2881 && monstername spectre of war`,
-        Macro.tryHaveItem(Item.get("T.U.R.D.S. Key"))
-      )
+      .tKey()
       .trySkill($skill`Launch spikolodon spikes`)
       .externalIf(
         haveEquipped($item`tearaway pants`),
         Macro.if_("!pastround 1 && monsterphylum plant", Macro.skill($skill`Tear Away your Pants!`))
       )
+      .waffle(island)
       .attack()
       .repeat("!pastround 3")
       .hardCombat();

--- a/src/macro.ts
+++ b/src/macro.ts
@@ -241,7 +241,7 @@ export default class Macro extends StrictMacro {
   waffle(island: HolidayIsland): this {
     if (args.waffles)
       return this.while_(
-        `hascombatitem waffle && !(${Macro.makeBALLSPredicate(island.avoidMonsters)})`,
+        `hascombatitem waffle && (${Macro.makeBALLSPredicate(island.avoidMonsters)})`,
         Macro.tKey()
           .tearawayPants()
           .item($item`waffle`)

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,5 @@
 import { Args } from "grimoire-kolmafia";
+import { print, toInt } from "kolmafia";
 import {
   $slots,
   Session,
@@ -8,11 +9,19 @@ import {
 } from "libram";
 
 import { CrimboEngine } from "./engine";
+import ISLANDS from "./islands";
 import { args, printh } from "./lib";
 import Tasks from "./tasks";
 
 export function main(command?: string) {
   Args.fill(args, command);
+  for (const island of Object.values(ISLANDS)) {
+    if (island.waffleAway.length === 0) {
+      print(`Error! Island ${island.location} has 0 monsters to waffle from!`, "red");
+    } else if (island.waffleAway.some((m) => !m || toInt(m) <= 2453)) {
+      print(`Error! Island ${island.location} has an invalid monster!`, "red");
+    }
+  }
 
   if (args.help) {
     Args.showHelp(args);

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,9 +16,9 @@ import Tasks from "./tasks";
 export function main(command?: string) {
   Args.fill(args, command);
   for (const island of Object.values(ISLANDS)) {
-    if (island.waffleAway.length === 0) {
+    if (island.avoidMonsters.length === 0) {
       print(`Error! Island ${island.location} has 0 monsters to waffle from!`, "red");
-    } else if (island.waffleAway.some((m) => !m || toInt(m) <= 2453)) {
+    } else if (island.avoidMonsters.some((m) => !m || toInt(m) <= 2453)) {
       print(`Error! Island ${island.location} has an invalid monster!`, "red");
     }
   }

--- a/src/outfit.ts
+++ b/src/outfit.ts
@@ -274,8 +274,8 @@ export function islandOutfit(
     }
   }
 
-  // Free run on reg fights
-  if (fight === "regular") {
+  // Free run on reg fights, but only if we wouldn't waffle away from them
+  if (fight === "regular" && !(args.waffles && itemAmount($item`waffle`))) {
     if (!outfit.haveEquipped($item`tearaway pants`) && have($item`Greatest American Pants`))
       outfit.equip($item`Greatest American Pants`);
     else if (!outfit.equips.has($slot`acc2`))

--- a/src/outfit.ts
+++ b/src/outfit.ts
@@ -275,7 +275,7 @@ export function islandOutfit(
   }
 
   // Free run on reg fights, but only if we wouldn't waffle away from them
-  if (fight === "regular" && !(args.waffles && itemAmount($item`waffle`))) {
+  if (args.freeruns && fight === "regular" && !(args.waffles && itemAmount($item`waffle`))) {
     if (!outfit.haveEquipped($item`tearaway pants`) && have($item`Greatest American Pants`))
       outfit.equip($item`Greatest American Pants`);
     else if (!outfit.equips.has($slot`acc2`))

--- a/src/outfit.ts
+++ b/src/outfit.ts
@@ -19,6 +19,7 @@ import {
   $familiars,
   $item,
   $phylum,
+  $slot,
   $stat,
   CrystalBall,
   get,
@@ -271,6 +272,14 @@ export function islandOutfit(
     } else if (getMonsters(island.location).some(({ phylum }) => phylum === $phylum`plant`)) {
       outfit.equip($item`tearaway pants`);
     }
+  }
+
+  // Free run on reg fights
+  if (fight === "regular") {
+    if (!outfit.haveEquipped($item`tearaway pants`) && have($item`Greatest American Pants`))
+      outfit.equip($item`Greatest American Pants`);
+    else if (!outfit.equips.has($slot`acc2`))
+      outfit.equip(ifHave("acc2", $item`navel ring of navel gazing`));
   }
 
   outfit.modifier = [`200 ${island.element} resistance 40 max`, "-100 combat -35 min", "-tie"];

--- a/src/tasks/island.ts
+++ b/src/tasks/island.ts
@@ -52,7 +52,7 @@ function freeRunTask(
     do: () => getIsland().location,
     sobriety: "sober",
     outfit: () => islandOutfit("freerun", source),
-    combat: new CrimboStrategy(() => Macro.islandRunWith(action)),
+    combat: new CrimboStrategy(() => Macro.islandRunWith(getIsland(), action)),
     ...fragment,
   };
 }

--- a/src/tasks/island.ts
+++ b/src/tasks/island.ts
@@ -38,7 +38,7 @@ function freeKillTask(
     do: () => getIsland().location,
     sobriety: "sober",
     outfit: () => islandOutfit("freekill", source),
-    combat: new CrimboStrategy(() => Macro.islandKillWith(action)),
+    combat: new CrimboStrategy(() => Macro.islandKillWith(getIsland(), action)),
     ...fragment,
   };
 }
@@ -232,7 +232,7 @@ export const ISLAND_QUEST: Quest<CrimboTask> = {
         name: "Island Adventuring",
         completed: () => myAdventures() === 0,
         do: () => getIsland().location,
-        combat: new CrimboStrategy(() => Macro.islandCombat()),
+        combat: new CrimboStrategy(() => Macro.islandCombat(getIsland())),
         outfit: () => islandOutfit("regular"),
         sobriety: "either",
       },

--- a/src/tasks/setup.ts
+++ b/src/tasks/setup.ts
@@ -72,7 +72,7 @@ export const SETUP_QUEST: Quest<CrimboTask> = {
       name: "Four-leaf potato sprout",
       completed: () => have($effect`Luck of St. Patrick`) || !have($item`four-leaf potato sprout`),
       do: () => use($item`four-leaf potato sprout`),
-      sobriety: "either"
+      sobriety: "either",
     },
     {
       name: "Disco Nap",

--- a/src/tasks/setup.ts
+++ b/src/tasks/setup.ts
@@ -69,6 +69,12 @@ export const SETUP_QUEST: Quest<CrimboTask> = {
       sobriety: "either",
     },
     {
+      name: "Four-leaf potato sprout",
+      completed: () => have($effect`Luck of St. Patrick`) || !have($item`four-leaf potato sprout`),
+      do: () => use($item`four-leaf potato sprout`),
+      sobriety: "either"
+    },
+    {
       name: "Disco Nap",
       ready: () => have($skill`Disco Nap`) && have($skill`Adventurer of Leisure`),
       completed: () => poisons.every((e) => !have(e)),


### PR DESCRIPTION

The script should work as normal unless the args "turdsKey" or "waffles" are flagged as true.
T.U.R.D.S. Key is a 20 turn counter for that one monster.
Waffles is definitely sub-optimal and can be improved with an arg to control what's waffled away.

Edit: further improvements, along with a fix for the script doing a free run against a desired monster 