### PR TITLE
Better support for TS prettier config

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -1,7 +1,7 @@
 import js from "@eslint/js";
-import { defineConfig } from "eslint/config";
 import prettier from "eslint-config-prettier";
 import libram, { verifyConstantsSinceRevision } from "eslint-plugin-libram";
+import { defineConfig } from "eslint/config";
 import tseslint from "typescript-eslint";
 
 await verifyConstantsSinceRevision(28806);
@@ -15,8 +15,11 @@ export default defineConfig(
   ...libram.configs.recommended,
   {
     rules: {
-      "libram/verify-constants": ["error", { data: { items: ["undertakers' forceps"] } }],
-    }
+      "libram/verify-constants": [
+        "error",
+        { data: { items: ["undertakers' forceps"] } },
+      ],
+    },
   },
   {
     files: ["**/*.ts", "**/*.tsx"],

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "build": "rollup -c rollup.config.ts --configPlugin @rollup/plugin-typescript",
     "format": "eslint src --fix --ext .ts && NODE_OPTIONS=\"--experimental-strip-types\" prettier --write src/**/*.ts",
-    "lint": "eslint src --ext .ts && prettier --check src/**/*.ts",
+    "lint": "eslint src --ext .ts &&  NODE_OPTIONS=\"--experimental-strip-types\" prettier --check src/**/*.ts",
     "watch": "node --import tsx build.ts --watch",
     "install-mafia": "create-kolmafia-script --install"
   },

--- a/package.json
+++ b/package.json
@@ -7,10 +7,13 @@
   "type": "module",
   "scripts": {
     "build": "rollup -c rollup.config.ts --configPlugin @rollup/plugin-typescript",
-    "format": "eslint src --fix --ext .ts && prettier --write src/**/*.ts",
+    "format": "eslint src --fix --ext .ts && NODE_OPTIONS=\"--experimental-strip-types\" prettier --write src/**/*.ts",
     "lint": "eslint src --ext .ts && prettier --check src/**/*.ts",
     "watch": "node --import tsx build.ts --watch",
     "install-mafia": "create-kolmafia-script --install"
+  },
+  "engines": {
+    "node": ">=24"
   },
   "dependencies": {
     "garbo-lib": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "type": "module",
   "scripts": {
     "build": "rollup -c rollup.config.ts --configPlugin @rollup/plugin-typescript",
-    "format": "eslint src --fix --ext .ts && NODE_OPTIONS=\"--experimental-strip-types\" prettier --write src/**/*.ts",
-    "lint": "eslint src --ext .ts &&  NODE_OPTIONS=\"--experimental-strip-types\" prettier --check src/**/*.ts",
+    "format": "eslint src --fix --ext .ts && NODE_OPTIONS=\"--experimental-strip-types\" prettier --write .",
+    "lint": "eslint src --ext .ts &&  NODE_OPTIONS=\"--experimental-strip-types\" prettier --check .",
     "watch": "node --import tsx build.ts --watch",
     "install-mafia": "create-kolmafia-script --install"
   },

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -1,10 +1,9 @@
 import babel from "@rollup/plugin-babel";
-import replace from "@rollup/plugin-replace";
-import resolve from "@rollup/plugin-node-resolve";
 import commonjs from "@rollup/plugin-commonjs";
+import resolve from "@rollup/plugin-node-resolve";
+import replace from "@rollup/plugin-replace";
 
-const watch =
-  process.argv.includes("--watch") || process.argv.includes("-w");
+const watch = process.argv.includes("--watch") || process.argv.includes("-w");
 
 export default {
   input: {
@@ -26,13 +25,13 @@ export default {
       preventAssignment: true,
       values: {
         "process.env.GITHUB_SHA": JSON.stringify(
-          process.env.GITHUB_SHA ?? "CustomBuild"
+          process.env.GITHUB_SHA ?? "CustomBuild",
         ),
         "process.env.GITHUB_REF_NAME": JSON.stringify(
-          process.env.GITHUB_REF_NAME ?? "CustomBuild"
+          process.env.GITHUB_REF_NAME ?? "CustomBuild",
         ),
         "process.env.GITHUB_REPOSITORY": JSON.stringify(
-          process.env.GITHUB_REPOSITORY ?? "CustomBuild"
+          process.env.GITHUB_REPOSITORY ?? "CustomBuild",
         ),
       },
     }),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,5 +15,5 @@
     "strict": true,
     "target": "es2018"
   },
-  "include": ["src/**/*.ts", "test/**/*.ts"],
+  "include": ["src/**/*.ts", "test/**/*.ts"]
 }


### PR DESCRIPTION
- **Strip types when running prettier and bump required node version to 24**
- **Do lint too**
- **Let's lint everything, not just src ts files**
